### PR TITLE
Fixing an issue with per file settings.

### DIFF
--- a/src/web/OpenAiRunner.ts
+++ b/src/web/OpenAiRunner.ts
@@ -13,13 +13,24 @@ export const MakeOpenAiRunner: (context: vscode.ExtensionContext) => Runner =
     }
 
     const config = vscode.workspace.getConfiguration("llm-book.openAI")
-    const model = config.get<string>("model") ?? "gpt-3.5-turbo"
-    const endpoint =
+    let model = config.get<string>("model") ?? "gpt-3.5-turbo"
+    let endpoint =
       config.get<string>("endpoint") ??
       "https://api.openai.com/v1/chat/completions"
 
     let options = config.get<object>("parameters") ?? {}
 
+    if (Object.prototype.hasOwnProperty.call(notebook.metadata.parameters, 'settings')) {
+      const clonedSettings = { ...notebook.metadata.parameters.settings };
+      delete notebook.metadata.parameters.settings;
+      if (Object.prototype.hasOwnProperty.call(clonedSettings, 'endpoint')) {
+        endpoint = clonedSettings.endpoint;
+      }
+      if (Object.prototype.hasOwnProperty.call(clonedSettings, 'model')) {
+        model = clonedSettings.model;
+      }
+    }
+  
     options = { ...options, ...notebook.metadata.parameters }
 
     console.log("Using options", options)


### PR DESCRIPTION
This is in relation to https://github.com/JacksonKearl/ai-book/issues/4
I noticed theer was code to get stuff from notebook.metadata.parameters and put it in the options field of OpenAI api request. I wanted a per file ability to specify endpoints (to use different models, including self hosted ones) so I added this code to handle an extra object under parametrs called settings. If it contains property of endpoint or model, it will override global config. Then settings is deleted and the rest of parameters is handled the same as before.

Hopefully it is of use to someone.